### PR TITLE
Include bunny count in Proportions table

### DIFF
--- a/js/NaturalSelectionStrings.ts
+++ b/js/NaturalSelectionStrings.ts
@@ -63,7 +63,7 @@ type StringsType = {
   'startOverStringProperty': LocalizedStringProperty;
   'bunniesHaveTakenOverTheWorldStringProperty': LocalizedStringProperty;
   'allOfTheBunniesHaveDiedStringProperty': LocalizedStringProperty;
-  'valuePercentStringProperty': LocalizedStringProperty;
+  'valuePercentAndCountStringProperty': LocalizedStringProperty;
   'lessThanValuePercentStringProperty': LocalizedStringProperty;
   'greaterThanValuePercentStringProperty': LocalizedStringProperty;
   'selectABunnyStringProperty': LocalizedStringProperty;

--- a/js/common/view/proportions/ProportionsBarNode.ts
+++ b/js/common/view/proportions/ProportionsBarNode.ts
@@ -28,7 +28,7 @@ import HatchingRectangle from '../HatchingRectangle.js';
 const PERCENTAGE_OPTIONS = {
   font: new PhetFont( 12 ),
   bottom: -4,
-  maxWidth: 40 // determined empirically
+  maxWidth: 60 // determined empirically
 };
 
 type SelfOptions = {
@@ -112,7 +112,7 @@ export default class ProportionsBarNode extends Node {
         this.valuesVisibleProperty,
         NaturalSelectionStrings.greaterThanValuePercentStringProperty,
         NaturalSelectionStrings.lessThanValuePercentStringProperty,
-        NaturalSelectionStrings.valuePercentStringProperty
+        NaturalSelectionStrings.valuePercentAndCountStringProperty
       ],
       () => this.updateProportionsBarNode()
     );
@@ -177,21 +177,23 @@ export default class ProportionsBarNode extends Node {
       }
 
       // round both percentages to the nearest integer
-      this.normalPercentageStringProperty.value = StringUtils.fillIn( NaturalSelectionStrings.valuePercentStringProperty.value, {
-        value: Utils.roundSymmetric( normalPercentage )
+      this.normalPercentageStringProperty.value = StringUtils.fillIn( NaturalSelectionStrings.valuePercentAndCountStringProperty.value, {
+        percent: Utils.roundSymmetric( normalPercentage ),
+        count: this.normalCount
       } );
-      this.mutantPercentageStringProperty.value = StringUtils.fillIn( NaturalSelectionStrings.valuePercentStringProperty.value, {
-        value: Utils.roundSymmetric( mutantPercentage )
+      this.mutantPercentageStringProperty.value = StringUtils.fillIn( NaturalSelectionStrings.valuePercentAndCountStringProperty.value, {
+        percent: Utils.roundSymmetric( mutantPercentage ),
+        count: this.mutantCount
       } );
     }
     this.mutantRectangle.right = this.normalRectangle.right;
 
-    // center N% above its portion of the bar
+    // center N% above its portion of the bar, but left/right-align it if the opposing bar has any width to avoid overlap
     if ( normalPercentage > 0 ) {
-      this.normalPercentageText.centerX = ( normalPercentage / 100 ) * ( this.barWidth / 2 );
+      this.normalPercentageText.centerX = mutantPercentage > 0 ? 0 : ( normalPercentage / 100 ) * ( this.barWidth / 2 );
     }
     if ( mutantPercentage > 0 ) {
-      this.mutantPercentageText.centerX = this.barWidth - ( ( mutantPercentage / 100 ) * ( this.barWidth / 2 ) );
+      this.mutantPercentageText.centerX = normalPercentage > 0 ? this.barWidth : this.barWidth - ( ( mutantPercentage / 100 ) * ( this.barWidth / 2 ) );
     }
 
     // horizontally constrain N% to left and right edges of bars

--- a/natural-selection-strings_en.json
+++ b/natural-selection-strings_en.json
@@ -140,8 +140,8 @@
   "allOfTheBunniesHaveDied": {
     "value": "All of the bunnies have died."
   },
-  "valuePercent": {
-    "value": "{{value}}%"
+  "valuePercentAndCount": {
+    "value": "{{percent}}% ({{count}})"
   },
   "lessThanValuePercent": {
     "value": "<{{value}}%"


### PR DESCRIPTION
Currently, it is impossible (or at least, hard to tell without counting) the bunny count of each mutation. In some worksheets, the exact count is required, so you have to multiply rounded percentages, yielding an incorrect count. 

This PR adds the exact bunny count next to the percentage in the proportion table to make this easier. I struggled a bit on the formatting since throwing a number there without anything after it (i.e., "32% (3)") makes it harder to determine what the number stands for, but adding a count label (i.e., "32% (3 bunnies)") caused the numbers to overlap. I've moved the text to the extremes of the graph to avoid this and stuck with the format of "N% (count)" (without the "bunnies" label).